### PR TITLE
Update get_embedding.py to fix a bug of querying genes

### DIFF
--- a/model/get_embedding.py
+++ b/model/get_embedding.py
@@ -78,7 +78,10 @@ def main():
     elif args.data_path[-4:]=='h5ad':
         gexpr_feature = sc.read_h5ad(args.data_path)
         idx = gexpr_feature.obs_names.tolist()
-        col = gexpr_feature.var.gene_name.tolist()
+        try:
+            col = gexpr_feature.var.gene_name.tolist()
+        except:
+            col = gexpr_feature.var_names.tolist()
         if issparse(gexpr_feature.X):
             gexpr_feature = gexpr_feature.X.toarray()
         else:


### PR DESCRIPTION
Hi, in the get_embedding.py code, the gene matching step requires that input h5ad file should have gene_name column, but no explict instructions. I believe most people will store gene names in var_names, so I add another option to avoid potential bugs. Thanks.