### PR TITLE
Fix shape mismatch error in gears caused by varying choose_binset

### DIFF
--- a/GEARS/gears/model.py
+++ b/GEARS/gears/model.py
@@ -134,9 +134,9 @@ class GEARS_Model(torch.nn.Module):
 
             ## get base gene embeddings
             if self.pretrained:
-                pre_in = x.clone().reshape(num_graphs, self.num_genes+1)
+                pre_in = x.clone().reshape(num_graphs, self.num_genes+1) # [n_genes + read_depth]
                 x = x.reshape(num_graphs, self.num_genes+1)[:,:-1]
-                emb = self.singlecell_model(pre_in)
+                emb = self.singlecell_model(pre_in) # depends on choose_binset, can be [n_genes], [n_genes + S token] or [n_genes + S_token + T_token]
                 if 'v1' in self.args['mode']:
                     pos_emb = self.emb_pos(torch.LongTensor(list(range(self.num_genes))).repeat(num_graphs, ).to(self.args['device']))
                 elif 'v2' in self.args['mode']:
@@ -144,6 +144,7 @@ class GEARS_Model(torch.nn.Module):
                 else:
                     print('error!')
                     exit()
+                emb = emb[:, :self.num_genes, :].contiguous() # only keep gene embeddings
                 emb = emb.view(-1, self.hidden_size)
             else:
                 x = x.reshape(num_graphs, self.num_genes+1)[:,:-1]

--- a/GEARS/gears/model.py
+++ b/GEARS/gears/model.py
@@ -32,7 +32,7 @@ class GEARS_Model(torch.nn.Module):
 
     def __init__(self, args):
         super(GEARS_Model, self).__init__()
-        self.args = args
+        self.args = args       
         self.num_genes = args['num_genes']
         self.num_perts = args['num_perts']
         hidden_size = args['hidden_size']
@@ -44,21 +44,21 @@ class GEARS_Model(torch.nn.Module):
         self.no_perturb = args['no_perturb']
         self.cell_fitness_pred = args['cell_fitness_pred']
         self.pert_emb_lambda = 0.2
-
+        
         # perturbation positional embedding added only to the perturbed genes
         self.pert_w = nn.Linear(1, hidden_size)
-
+           
         # gene/globel perturbation embedding dictionary lookup            
         self.gene_emb = nn.Embedding(self.num_genes, hidden_size, max_norm=True)
         self.pert_emb = nn.Embedding(self.num_perts, hidden_size, max_norm=True)
-
+        
         # transformation layer
         self.emb_trans = nn.ReLU()
         self.pert_base_trans = nn.ReLU()
         self.transform = nn.ReLU()
         self.emb_trans_v2 = MLP([hidden_size, hidden_size, hidden_size], last_layer_act='ReLU')
         self.pert_fuse = MLP([hidden_size, hidden_size, hidden_size], last_layer_act='ReLU')
-
+        
         # gene co-expression GNN
         self.G_coexpress = args['G_coexpress'].to(args['device'])
         self.G_coexpress_weight = args['G_coexpress_weight'].to(args['device'])
@@ -67,7 +67,7 @@ class GEARS_Model(torch.nn.Module):
         self.layers_emb_pos = torch.nn.ModuleList()
         for i in range(1, self.num_layers_gene_pos + 1):
             self.layers_emb_pos.append(SGConv(hidden_size, hidden_size, 1))
-
+        
         ### perturbation gene ontology GNN
         self.G_sim = args['G_go'].to(args['device'])
         self.G_sim_weight = args['G_go_weight'].to(args['device'])
@@ -75,10 +75,10 @@ class GEARS_Model(torch.nn.Module):
         self.sim_layers = torch.nn.ModuleList()
         for i in range(1, self.num_layers + 1):
             self.sim_layers.append(SGConv(hidden_size, hidden_size, 1))
-
+        
         # decoder shared MLP
         self.recovery_w = MLP([hidden_size, hidden_size*2, hidden_size], last_layer_act='linear')
-
+        
         # gene specific decoder
         self.indv_w1 = nn.Parameter(torch.rand(self.num_genes,
                                                hidden_size, 1))
@@ -86,7 +86,7 @@ class GEARS_Model(torch.nn.Module):
         self.act = nn.ReLU()
         nn.init.xavier_normal_(self.indv_w1)
         nn.init.xavier_normal_(self.indv_b1)
-
+        
         # Cross gene MLP
         self.cross_gene_state = MLP([self.num_genes, hidden_size,
                                      hidden_size])
@@ -96,19 +96,19 @@ class GEARS_Model(torch.nn.Module):
         self.indv_b2 = nn.Parameter(torch.rand(1, self.num_genes))
         nn.init.xavier_normal_(self.indv_w2)
         nn.init.xavier_normal_(self.indv_b2)
-
+        
         # batchnorms
         self.bn_emb = nn.BatchNorm1d(hidden_size)
         self.bn_pert_base = nn.BatchNorm1d(hidden_size)
         self.bn_pert_base_trans = nn.BatchNorm1d(hidden_size)
-
+        
         # uncertainty mode
         if self.uncertainty:
             self.uncertainty_w = MLP([hidden_size, hidden_size*2, hidden_size, 1], last_layer_act='linear')
-
+        
         #if self.cell_fitness_pred:
         self.cell_fitness_mlp = MLP([self.num_genes, hidden_size*2, hidden_size, 1], last_layer_act='linear')
-
+        
         if args['model_type'] == 'maeautobin':
             from modules.encoders import MAEAutobinencoder
             self.singlecell_model = MAEAutobinencoder(args, hidden_size=hidden_size)
@@ -127,7 +127,7 @@ class GEARS_Model(torch.nn.Module):
         x, pert_idx = data.x, data.pert_idx
         if self.no_perturb:
             out = x.reshape(-1,1)
-            out = torch.split(torch.flatten(out), self.num_genes)
+            out = torch.split(torch.flatten(out), self.num_genes)           
             return torch.stack(out)
         else:
             num_graphs = len(data.batch.unique())
@@ -151,7 +151,7 @@ class GEARS_Model(torch.nn.Module):
                 emb = self.gene_emb(torch.LongTensor(list(range(self.num_genes))).repeat(num_graphs, ).to(self.args['device']))
                 pos_emb = self.emb_pos(torch.LongTensor(list(range(self.num_genes))).repeat(num_graphs, ).to(self.args['device']))
             emb = self.bn_emb(emb)
-            base_emb = self.emb_trans(emb)
+            base_emb = self.emb_trans(emb)        
             # pos_emb = emb
             for idx, layer in enumerate(self.layers_emb_pos):
                 pos_emb = layer(pos_emb, self.G_coexpress, self.G_coexpress_weight)
@@ -170,7 +170,7 @@ class GEARS_Model(torch.nn.Module):
                         pert_index.append([idx, j])
             pert_index = torch.tensor(pert_index).T
 
-            pert_global_emb = self.pert_emb(torch.LongTensor(list(range(self.num_perts))).to(self.args['device']))
+            pert_global_emb = self.pert_emb(torch.LongTensor(list(range(self.num_perts))).to(self.args['device']))        
 
             ## augment global perturbation embedding with GNN
             for idx, layer in enumerate(self.sim_layers):
@@ -204,7 +204,7 @@ class GEARS_Model(torch.nn.Module):
             base_emb = self.bn_pert_base(base_emb)
 
             ## apply the first MLP
-            base_emb = self.transform(base_emb)
+            base_emb = self.transform(base_emb)        
             out = self.recovery_w(base_emb)
             out = out.reshape(num_graphs, self.num_genes, -1)
             out = out.unsqueeze(-1) * self.indv_w1
@@ -220,7 +220,7 @@ class GEARS_Model(torch.nn.Module):
 
             cross_gene_out = cross_gene_out * self.indv_w2
             cross_gene_out = torch.sum(cross_gene_out, axis=2)
-            out = cross_gene_out + self.indv_b2
+            out = cross_gene_out + self.indv_b2        
             out = out.reshape(num_graphs * self.num_genes, -1) + x.reshape(-1,1)
             out = torch.split(torch.flatten(out), self.num_genes)
 
@@ -229,9 +229,9 @@ class GEARS_Model(torch.nn.Module):
                 out_logvar = self.uncertainty_w(base_emb)
                 out_logvar = torch.split(torch.flatten(out_logvar), self.num_genes)
                 return torch.stack(out), torch.stack(out_logvar)
-
+            
             if self.cell_fitness_pred:
                 return torch.stack(out), self.cell_fitness_mlp(torch.stack(out))
-
+            
             return torch.stack(out)
-
+        

--- a/GEARS/gears/model.py
+++ b/GEARS/gears/model.py
@@ -32,7 +32,7 @@ class GEARS_Model(torch.nn.Module):
 
     def __init__(self, args):
         super(GEARS_Model, self).__init__()
-        self.args = args       
+        self.args = args
         self.num_genes = args['num_genes']
         self.num_perts = args['num_perts']
         hidden_size = args['hidden_size']
@@ -44,21 +44,21 @@ class GEARS_Model(torch.nn.Module):
         self.no_perturb = args['no_perturb']
         self.cell_fitness_pred = args['cell_fitness_pred']
         self.pert_emb_lambda = 0.2
-        
+
         # perturbation positional embedding added only to the perturbed genes
         self.pert_w = nn.Linear(1, hidden_size)
-           
+
         # gene/globel perturbation embedding dictionary lookup            
         self.gene_emb = nn.Embedding(self.num_genes, hidden_size, max_norm=True)
         self.pert_emb = nn.Embedding(self.num_perts, hidden_size, max_norm=True)
-        
+
         # transformation layer
         self.emb_trans = nn.ReLU()
         self.pert_base_trans = nn.ReLU()
         self.transform = nn.ReLU()
         self.emb_trans_v2 = MLP([hidden_size, hidden_size, hidden_size], last_layer_act='ReLU')
         self.pert_fuse = MLP([hidden_size, hidden_size, hidden_size], last_layer_act='ReLU')
-        
+
         # gene co-expression GNN
         self.G_coexpress = args['G_coexpress'].to(args['device'])
         self.G_coexpress_weight = args['G_coexpress_weight'].to(args['device'])
@@ -67,7 +67,7 @@ class GEARS_Model(torch.nn.Module):
         self.layers_emb_pos = torch.nn.ModuleList()
         for i in range(1, self.num_layers_gene_pos + 1):
             self.layers_emb_pos.append(SGConv(hidden_size, hidden_size, 1))
-        
+
         ### perturbation gene ontology GNN
         self.G_sim = args['G_go'].to(args['device'])
         self.G_sim_weight = args['G_go_weight'].to(args['device'])
@@ -75,10 +75,10 @@ class GEARS_Model(torch.nn.Module):
         self.sim_layers = torch.nn.ModuleList()
         for i in range(1, self.num_layers + 1):
             self.sim_layers.append(SGConv(hidden_size, hidden_size, 1))
-        
+
         # decoder shared MLP
         self.recovery_w = MLP([hidden_size, hidden_size*2, hidden_size], last_layer_act='linear')
-        
+
         # gene specific decoder
         self.indv_w1 = nn.Parameter(torch.rand(self.num_genes,
                                                hidden_size, 1))
@@ -86,7 +86,7 @@ class GEARS_Model(torch.nn.Module):
         self.act = nn.ReLU()
         nn.init.xavier_normal_(self.indv_w1)
         nn.init.xavier_normal_(self.indv_b1)
-        
+
         # Cross gene MLP
         self.cross_gene_state = MLP([self.num_genes, hidden_size,
                                      hidden_size])
@@ -96,19 +96,19 @@ class GEARS_Model(torch.nn.Module):
         self.indv_b2 = nn.Parameter(torch.rand(1, self.num_genes))
         nn.init.xavier_normal_(self.indv_w2)
         nn.init.xavier_normal_(self.indv_b2)
-        
+
         # batchnorms
         self.bn_emb = nn.BatchNorm1d(hidden_size)
         self.bn_pert_base = nn.BatchNorm1d(hidden_size)
         self.bn_pert_base_trans = nn.BatchNorm1d(hidden_size)
-        
+
         # uncertainty mode
         if self.uncertainty:
             self.uncertainty_w = MLP([hidden_size, hidden_size*2, hidden_size, 1], last_layer_act='linear')
-        
+
         #if self.cell_fitness_pred:
         self.cell_fitness_mlp = MLP([self.num_genes, hidden_size*2, hidden_size, 1], last_layer_act='linear')
-        
+
         if args['model_type'] == 'maeautobin':
             from modules.encoders import MAEAutobinencoder
             self.singlecell_model = MAEAutobinencoder(args, hidden_size=hidden_size)
@@ -127,7 +127,7 @@ class GEARS_Model(torch.nn.Module):
         x, pert_idx = data.x, data.pert_idx
         if self.no_perturb:
             out = x.reshape(-1,1)
-            out = torch.split(torch.flatten(out), self.num_genes)           
+            out = torch.split(torch.flatten(out), self.num_genes)
             return torch.stack(out)
         else:
             num_graphs = len(data.batch.unique())
@@ -138,7 +138,7 @@ class GEARS_Model(torch.nn.Module):
                 x = x.reshape(num_graphs, self.num_genes+1)[:,:-1]
                 emb = self.singlecell_model(pre_in) # depends on choose_binset, can be [n_genes], [n_genes + S token] or [n_genes + S_token + T_token]
                 if 'v1' in self.args['mode']:
-                    pos_emb = self.emb_pos(torch.LongTensor(list(range(self.num_genes))).repeat(num_graphs, ).to(self.args['device']))
+                    pos_emb = self.emb_pos(torch.LongTensor(list(range(self.num_genes))).repeat(num_graphs, ).to(self.args['device'])) # [n_genes, hidden_size]
                 elif 'v2' in self.args['mode']:
                     pos_emb = emb.view(-1, self.hidden_size)
                 else:
@@ -151,7 +151,7 @@ class GEARS_Model(torch.nn.Module):
                 emb = self.gene_emb(torch.LongTensor(list(range(self.num_genes))).repeat(num_graphs, ).to(self.args['device']))
                 pos_emb = self.emb_pos(torch.LongTensor(list(range(self.num_genes))).repeat(num_graphs, ).to(self.args['device']))
             emb = self.bn_emb(emb)
-            base_emb = self.emb_trans(emb)        
+            base_emb = self.emb_trans(emb)
             # pos_emb = emb
             for idx, layer in enumerate(self.layers_emb_pos):
                 pos_emb = layer(pos_emb, self.G_coexpress, self.G_coexpress_weight)
@@ -170,7 +170,7 @@ class GEARS_Model(torch.nn.Module):
                         pert_index.append([idx, j])
             pert_index = torch.tensor(pert_index).T
 
-            pert_global_emb = self.pert_emb(torch.LongTensor(list(range(self.num_perts))).to(self.args['device']))        
+            pert_global_emb = self.pert_emb(torch.LongTensor(list(range(self.num_perts))).to(self.args['device']))
 
             ## augment global perturbation embedding with GNN
             for idx, layer in enumerate(self.sim_layers):
@@ -204,7 +204,7 @@ class GEARS_Model(torch.nn.Module):
             base_emb = self.bn_pert_base(base_emb)
 
             ## apply the first MLP
-            base_emb = self.transform(base_emb)        
+            base_emb = self.transform(base_emb)
             out = self.recovery_w(base_emb)
             out = out.reshape(num_graphs, self.num_genes, -1)
             out = out.unsqueeze(-1) * self.indv_w1
@@ -220,7 +220,7 @@ class GEARS_Model(torch.nn.Module):
 
             cross_gene_out = cross_gene_out * self.indv_w2
             cross_gene_out = torch.sum(cross_gene_out, axis=2)
-            out = cross_gene_out + self.indv_b2        
+            out = cross_gene_out + self.indv_b2
             out = out.reshape(num_graphs * self.num_genes, -1) + x.reshape(-1,1)
             out = torch.split(torch.flatten(out), self.num_genes)
 
@@ -229,9 +229,9 @@ class GEARS_Model(torch.nn.Module):
                 out_logvar = self.uncertainty_w(base_emb)
                 out_logvar = torch.split(torch.flatten(out_logvar), self.num_genes)
                 return torch.stack(out), torch.stack(out_logvar)
-            
+
             if self.cell_fitness_pred:
                 return torch.stack(out), self.cell_fitness_mlp(torch.stack(out))
-            
+
             return torch.stack(out)
-        
+


### PR DESCRIPTION
#### Issue:
In the `gears` module, using different `binset configurations` results in a varying number of tokens. This causes a shape mismatch error when attempting to add `positional embeddings`, as the sequence length exceeds or differs from the expected dimensions (`positional embeddings` is always `[num_genes, hidden_size]`)

#### Fix:
I added a truncation operation to ensure the input sequence length aligns with the model's expectations. The code now explicitly slices the input to keep only the first `num_genes` tokens before adding `positional embeddings`.